### PR TITLE
Use npm bin for script references in base of NODE_PATH is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress --colors --inline --host 0.0.0.0",
-    "watch": "node ./node_modules/webpack/bin/webpack.js --progress --colors --watch",
-    "build": "node ./node_modules/webpack/bin/webpack.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "$(npm bin)/webpack-dev-server --progress --colors --inline --host 0.0.0.0",
+    "watch": "$(npm bin)/webpack --progress --colors --watch",
+    "build": "$(npm bin)/webpack"
   },
   "author": "Serge Paquet",
   "license": "MIT",


### PR DESCRIPTION
Hi Serge,

Was trying out your map library quick. Good job on it.

I made a small improvement on the package.json.

If I have NODE_PATH set on my system, the node_modules won't be located at the root of the app.

We can fetch the bin path using $(npm bin).

I also removed the test script as the lib currently doesn't have any unit test.

Thanks for looking into it.
